### PR TITLE
Consolidate build-system into setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+backend = "build_sdist"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+cryptography>=3.1
+ircchallenge==0.1.1
+pyyaml      >=5.3.1
+Twisted     >=20.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-cryptography>=3.1
-ircchallenge==0.1.1
-pyyaml      >=5.3.1
-Twisted     >=20.3.0

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,9 @@
 
 from distutils.core import setup
 
+with open("requirements.txt", "r") as requirements_file:
+    install_requires = requirements_file.read().splitlines()
+
 setup(
     name="twisted-opm",
     version="0.1",
@@ -12,11 +15,5 @@ setup(
     license="MIT",
     packages=["opm", "opm/plugins", "twisted/plugins"],
     python_requires=">=3.5",
-    install_requires=[
-        'cryptography>=3.1',
-        'ircchallenge==0.1.1',
-        'pyyaml      >=5.3.1',
-        'Twisted     >=20.3.0',
-        'pyOpenSSL   >=20.0.1',
-    ]
+    install_requires=install_requires
 )

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,13 @@ setup(
     url="https://github.com/jesopo/twisted-opm",
     description="Twisted-based BOPM-like open proxy scanner.",
     license="MIT",
-    packages=["opm", "twisted/plugins"],
-    python_requires=">=3.5"
+    packages=["opm", "opm/plugins", "twisted/plugins"],
+    python_requires=">=3.5",
+    install_requires=[
+        'cryptography>=3.1',
+        'ircchallenge==0.1.1',
+        'pyyaml      >=5.3.1',
+        'Twisted     >=20.3.0',
+        'pyOpenSSL   >=20.0.1',
+    ]
 )


### PR DESCRIPTION
I'm not a Python expert, so there might be some idioms here I don't know. However this change allows me to `pip3 install .` without any other interventions. For working out of the source directory there's a flag, I believe, so that edits to your python files show up. This might be better than a requirements.txt *and* a setup.py