### PR TITLE
switch to per-scanset actions

### DIFF
--- a/opm.conf
+++ b/opm.conf
@@ -30,9 +30,6 @@ target_strings: ['Proxy Check', 'sdIv:;aL{l*h?[?Q4-xiYf9QSi3U&7edDCVZ3z<t']
 max_bytes: 16384
 # optional address to connect from
 #bind_address: '192.168.1.33'
-# default user-reason and oper-reason
-user-reason: 'Open proxy detected'
-oper-reason: 'Open proxy ({DESC})'
 
 irc:
   # IRC presence, used to take connect snotes and commands and set klines.
@@ -70,9 +67,6 @@ irc:
     # maximum size of IP scan cache
     scan-cache-size: 1000000
     # Commands to send if an open proxy is found.
-    actions:
-      - 'KLINE 1440 *@{IP} :{UREAS}'
-      - 'NOTICE {CHAN} :BAD {MASK} ({OREAS})'
 scansets:
   # Named groups of scans to run. Each group of scans shares a timeout
   # (the timeout is applied to each scan individually, not to the entire
@@ -82,6 +76,8 @@ scansets:
   # What the extra args do depends on the scanner.
   default:
     timeout: 60
+      - 'KLINE 1440 *@{IP} :You running an open proxy'
+      - 'NOTICE {CHAN} :BAD {MASK} ({REASON} - scan)'
     protocols:
       - [high-prio, http, 80]
       - [high-prio, http, 8080]
@@ -100,8 +96,9 @@ scansets:
       - [high-prio, http-post, 3128]
   dronebl:
     timeout: 10
-    user-reason: 'IP Listed in DroneBL. see https://dronebl.org/lookup?ip={IP}'
-    oper-reason: 'IP Listen in DroneBL ({DESC})'
+    actions:
+      - 'KLINE 1440 *@{IP} :You have a host listed in DroneBL https://dronebl.org/lookup?ip={IP}'
+      - 'NOTICE {CHAN} :BAD {MASK} ({REASON} - dronebl)'
     protocols:
       - [dns, dnsbl, dnsbl.dronebl.org, {
          1: Testing,
@@ -122,25 +119,19 @@ scansets:
          }]
   certs:
     timeout: 10
-    user-reason: 'Banned VPN service'
-    oper-reason: 'Banned VPN service ({DESC})'
+    actions:
+      - 'KLINE 1440 *@{IP} :You are connecting from an abusable host'
+      - 'NOTICE {CHAN} :BAD {MASK} ({REASON} - cert)'
     protocols:
       - [high-prio, cert, 443, {
           'scn:myvpn\.tld':     'Test VPN',
           's[ca]n:.*\.vpn.tld': 'Test VPN 2'
         }]
-  rdns:
-    timeout: 10
-    user-reason: 'Banned VPN service'
-    oper-reason: 'Banned VPN service ({DESC})'
-    protocols:
-      - [high-prio, rdns, {
-          '(?:[^.]+\.)vpn.tld': 'Test VPN'
-        }]
   http-headers:
     timeout: 10
-    user-reason: 'Banned VPN service'
-    oper-reason: 'Banned VPN service ({DESC})'
+    actions:
+      - 'KLINE 1440 *@{IP} :You are connecting from an abusable host'
+      - 'NOTICE {CHAN} :BAD {MASK} ({REASON} - header)'
     protocols:
       - [high-prio, tcp-banner, 80, {
         "Test VPN": [
@@ -151,8 +142,9 @@ scansets:
 
   http-body:
     timeout: 10
-    user-reason: 'Banned VPN service'
-    oper-reason: 'Banned VPN service ({DESC})'
+    actions:
+      - 'KLINE 1440 *@{IP} :You are connecting from an abusable host'
+      - 'NOTICE {CHAN} :BAD {MASK} ({REASON} - body)'
     protocols:
       - [high-prio, http-body, 80, {
           "7dd71afcfb14e105e80b0c0d7fce370a28a41f0a": "Lolnerd VPN"

--- a/opm/conf.py
+++ b/opm/conf.py
@@ -79,9 +79,6 @@ def makeService(options):
 
     checkerFactories = plugin.getCheckerFactories()
 
-    default_user_reason = options['conf'].get('user-reason', '')
-    default_oper_reason = options['conf'].get('oper-reason', '')
-
     scansets = {}
     for name, d in options['conf']['scansets'].items():
         scans = []
@@ -91,10 +88,8 @@ def makeService(options):
             checker = checkerFactories[checkername](*args)
             scans.append((poolname, checker.check))
 
-        user_reason = d.get('user-reason', default_user_reason)
-        oper_reason = d.get('oper-reason', default_oper_reason)
-        scansets[name] = scanner.ScanSet(d['timeout'], scans, user_reason,
-                                         oper_reason)
+        actions = d.get('actions', [])
+        scansets[name] = scanner.ScanSet(d['timeout'], scans, actions)
 
     # XXXX the target_blah passing here is horrible, but I intend to
     # make this less global in the future anyway, so laaaaaaaaater

--- a/opm/ircpresence.py
+++ b/opm/ircpresence.py
@@ -186,18 +186,16 @@ class Client(irc.IRCClient):
         if result is not None:
             scanset, result = result
             formats = {
+                'IP': ip,
                 'NICK': nick,
                 'USER': user,
-                'IP':   ip,
                 'HOST': host,
                 'MASK': ux_hostmask,
-                'DESC': result,
-                'CHAN': self.factory.channel
+                'CHAN': self.factory.channel,
+                'REASON': result,
             }
-            formats['UREAS'] = scanset.user_reason.format(**formats)
-            formats['OREAS'] = scanset.oper_reason.format(**formats)
 
-            for action in self.factory.actions:
+            for action in scanset.actions:
                 self.sendLine(action.format(**formats))
 
             log.msg('KILL {MASK} for {OREAS}'.format(**formats))

--- a/opm/scanner.py
+++ b/opm/scanner.py
@@ -145,11 +145,10 @@ class Scan(object):
             self._setResult(None)
 
 class ScanSet(object):
-    def __init__(self, timeout, scans, user_reason, oper_reason):
+    def __init__(self, timeout, scans, actions):
         self.timeout = timeout
         self.scans   = scans
-        self.user_reason = user_reason
-        self.oper_reason = oper_reason
+        self.actions = actions
 
 class ScanEnvironment(object):
 


### PR DESCRIPTION
`OREAS` and `UREAS` only existed for use in reporting and k-lines, respectively, so they're a bit pointless now - thus I've removed them. now you can just use `{REASON}` to be replaced with whatever technical detail topm used to decide they're bad (best only used in oper-facing things)